### PR TITLE
fix: job status

### DIFF
--- a/src/llama_stack_provider_kft/kft_adapter.py
+++ b/src/llama_stack_provider_kft/kft_adapter.py
@@ -276,11 +276,29 @@ class InstructLabKubeFlowPostTrainingImpl:
     async def get_training_job_status(self, job_uuid: str) -> Optional[PostTrainingJobStatusResponse]:
         job = self._scheduler.get_job(job_uuid)
 
+
+        match job.status:
+             # TODO: Add support for other statuses to API
+             case SchedulerJobStatus.new | SchedulerJobStatus.scheduled:
+                 status = SchedulerJobStatus.scheduled
+             case SchedulerJobStatus.running:
+                 status = SchedulerJobStatus.in_progress
+             case SchedulerJobStatus.completed:
+                 status = SchedulerJobStatus.completed
+             case SchedulerJobStatus.failed:
+                 status = SchedulerJobStatus.failed
+             case _:
+                 raise NotImplementedError()
+ 
         return PostTrainingJobStatusResponse(
-            job_uuid=job_uuid,
-            status=job.status,
-            scheduled_at=job.scheduled_at,
-        )
+             job_uuid=job_uuid,
+             status=status,
+             scheduled_at=job.scheduled_at,
+             started_at=job.started_at,
+             completed_at=job.completed_at,
+             checkpoints=self._get_checkpoints(job),
+             resources_allocated=self._get_resources_allocated(job),
+         )
 
     async def cancel_training_job(self, job_uuid: str) -> None:
         raise NotImplementedError("Job cancel is not implemented yet")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

currently get_training_job_status errors out like so:

```
status
  Input should be 'completed', 'in_progress', 'failed', 'scheduled' or 'cancelled' [type=enum, input_value=<JobStatus.failed: 'failed'>, input_type=JobStatus]
    For further information visit https://errors.pydantic.dev/2.11/v/enum
```

Fix this by matching the job status properly and returning a valid one


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
