### PR TITLE
fix: better handling for failures

### DIFF
--- a/src/llama_stack_provider_kft/kft_adapter.py
+++ b/src/llama_stack_provider_kft/kft_adapter.py
@@ -231,7 +231,11 @@ class InstructLabKubeFlowPostTrainingImpl:
 
                 # Run the pytorch job
                 logger.info(f"Creating PyTorchJob in namespace: {namespace}")
-                training_client.create_job(job_template, namespace=namespace)
+                try:
+                    training_client.create_job(job_template, namespace=namespace)
+                except Exception as exc:
+                    logger.error(f"Failed to create PyTorchJob {str(exc)}")
+                    raise
 
                 expected_conditions = ["Succeeded", "Failed"]
                 logger.info(f"Monitoring job until status is any of {expected_conditions}.")


### PR DESCRIPTION
## Description

when a PyTorchJob isn't created, we should catch that and error out. Currently we just keep going and wait for a the job to "complete"

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
