### PR TITLE
feat: ability to keep last epoch only

### DIFF
--- a/src/llama_stack_provider_kft/config.py
+++ b/src/llama_stack_provider_kft/config.py
@@ -25,6 +25,7 @@ class InstructLabKubeFlowPostTrainingConfig(BaseModel):
     job_timeout: int = 86400
     nnodes: int = 2
     delete_after_done: bool = False
+    keep_last_checkpoint_only: bool = False
 
     @classmethod
     def sample_run_config(cls, **kwargs) -> Dict[str, Any]:

--- a/src/llama_stack_provider_kft/kft_adapter.py
+++ b/src/llama_stack_provider_kft/kft_adapter.py
@@ -82,6 +82,7 @@ class InstructLabKubeFlowPostTrainingImpl:
             # seed: int = self.config.seed,
             # job_timeout: int = 86400,
             # delete_after_done: bool = False,
+            # keep_last_checkpoint_only: bool = False,
         ):
             from kubeflow.training import TrainingClient, models
             from kubeflow.training.constants.constants import ISTIO_SIDECAR_INJECTION
@@ -105,6 +106,12 @@ class InstructLabKubeFlowPostTrainingImpl:
             name = f"train-phase{self.config.phase_num}-{self.config.name_suffix.rstrip('-sdg')}"
             command = ["/bin/sh", "-c", "--"]
 
+            # This feels like a hack, we can probably do this better
+            keep_last_checkpoint = (
+                "--keep_last_checkpoint_only"
+                if self.config.keep_last_checkpoint_only
+                else ""
+            )
             master_args = [
                 f"""
                     echo "Running Training Phase"
@@ -129,8 +136,9 @@ class InstructLabKubeFlowPostTrainingImpl:
                     --cpu_offload_optimizer \
                     --cpu_offload_params_fsdp \
                     --distributed_training_framework fsdp \
-                    --checkpoint_at_epoch
+                    --checkpoint_at_epoch {keep_last_checkpoint}
                     """
+                # space between --checkpoint_at_epoch and {keep_last_checkpoint} is intentional DO NOT REMOVE
             ]
 
             # Set volumes


### PR DESCRIPTION
Add a parameter to control if the training run show overwrite each epoch. This is useful for training phase 1 since only care about the 7th epoch and will help us remove some of the storage requirements.

See https://github.com/instructlab/training/pull/358 for more context.