### PR TITLE
feat: support data processing as an optional pre-flight

### DIFF
--- a/run.yaml
+++ b/run.yaml
@@ -21,4 +21,5 @@ providers:
       name_suffix: ilab
       phase_num: 1
       base_image: registry.redhat.io/rhelai1/instructlab-nvidia-rhel9
+      preprocess: True
 external_providers_dir: ./providers.d

--- a/src/llama_stack_provider_kft/config.py
+++ b/src/llama_stack_provider_kft/config.py
@@ -26,6 +26,9 @@ class InstructLabKubeFlowPostTrainingConfig(BaseModel):
     nnodes: int = 2
     delete_after_done: bool = False
     keep_last_checkpoint_only: bool = False
+    preprocess: bool = False
+    chat_tmpl_path: str = None
+    max_seq_len: int = 4096
 
     @classmethod
     def sample_run_config(cls, **kwargs) -> Dict[str, Any]:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

in order for SDG data to be used by Instructlab Training, the data needs to be run through the data_process package before training.

If users are coming directly from SDG to training, this should be an optional pre-flight conversion inside of the provider

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
