### PR TITLE
chore: minor changes to test-external-providers workflow

### DIFF
--- a/.github/workflows/test-external-providers.yml
+++ b/.github/workflows/test-external-providers.yml
@@ -24,28 +24,29 @@ jobs:
           uv pip install -e .
 
       - name: Start Llama Stack server in background
-        run: |
-          source .venv/bin/activate
-          touch server.log
-          LLAMA_STACK_LOG_FILE=server.log nohup uv run llama stack run run.yaml --image-type venv &
+        run: LLAMA_STACK_LOG_FILE=server.log nohup uv run llama stack run run.yaml --image-type venv &
 
       - name: Wait for Llama Stack server to be ready
         run: |
           echo "Waiting for Llama Stack server..."
           for i in {1..30}; do
-            if curl -s http://localhost:8321/v1/health | grep -q "OK"; then
+            resp=$(curl -s http://localhost:8321/v1/health)
+            if [ "$resp" == '{"status":"OK"}' ]; then
               echo "Llama Stack server is up!"
               if grep -q -e "remote::instructlab_kft from .*providers.d/remote/post_training/instructlab_kft.yaml" server.log; then
                 echo "Llama Stack server is using InstructLab KFT provider"
                 exit 0
               else
                 echo "Llama Stack server is not using InstructLab KFT provider"
+                echo "Server logs:"
+                cat server.log
                 exit 1
               fi
             fi
             sleep 1
           done
           echo "Llama Stack server failed to start"
+          echo "Server logs:"
           cat server.log
           exit 1
 


### PR DESCRIPTION
do a more exact check for the Llama Stack server health and dump server logs for all failures

based on some similar changes I made here: https://github.com/containers/ramalama-stack/pull/28