### PR TITLE
fix: out-of-date reference to requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,8 @@ WORKDIR /app
 # Copy pre-built wheel from builder
 COPY --from=builder /app/dist/*.whl .
 
-# Copy and install runtime dependencies and pre-built python wheel
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt *.whl
+# Install runtime dependencies and pre-built python wheel
+RUN pip install --no-cache-dir *.whl
 
 # Copy config files
 COPY run.yaml .


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
It was requested in https://github.com/opendatahub-io/llama-stack-provider-kft/pull/26 to consolidate dependencies into `pyproject.toml` instead of `requirements.txt` but this left an out-of-date reference in the Dockerfile

## How Has This Been Tested?
There's no docs around building the container locally, and it seems the CI action for it is broken

Happy to try a local build if I can get some guidance here around it 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
