### PR TITLE
ci: always build on PRs to main, only push on merges to main

### DIFF
--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -2,7 +2,11 @@ name: Build and Publish Image to quay.io
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 
 jobs:
   build-and-publish:
@@ -17,6 +21,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to quay.io
+        if: ${{ github.event_name == 'push' }}
         uses: docker/login-action@v3
         with:
           registry: quay.io
@@ -32,4 +37,4 @@ jobs:
           tags: |
             quay.io/opendatahub/llama-stack-provider-kft:amd64
             quay.io/opendatahub/llama-stack-provider-kft:arm64
-          push: true
+          push: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
## Description
This modifies the Container action to always attempt a build on PRs, but only push to quay on merges 

## How Has This Been Tested?
Should run against this PR

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
